### PR TITLE
feat: 카카오 로그인 응답 코드 및 JWT 페이로드 변경

### DIFF
--- a/src/main/java/com/hsp/fitu/controller/AuthController.java
+++ b/src/main/java/com/hsp/fitu/controller/AuthController.java
@@ -18,7 +18,12 @@ public class AuthController {
 
     @GetMapping("/login/kakao")
     public ResponseEntity<String> kakaoLogin(@RequestParam("code") String accessCode, HttpServletResponse httpServletResponse) {
-        authService.oAuthLogin(accessCode, httpServletResponse);
-        return ResponseEntity.ok("카카오 로그인 완료");
+        boolean isNewUser = authService.oAuthLogin(accessCode, httpServletResponse);
+
+        if (isNewUser) {
+            return ResponseEntity.status(201).body("카카오 회원가입 완료");
+        } else {
+            return ResponseEntity.ok("카카오 로그인 완료");
+        }
     }
 }

--- a/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
@@ -10,6 +10,7 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Map;
 
 @Component
 public class JwtUtil {
@@ -24,13 +25,13 @@ public class JwtUtil {
         accessExpMs = access;
     }
 
-    public String createAccessToken(String kakaoEmail) {
+    public String createAccessToken(long userId) {
         Instant now = Instant.now();
         Instant expiration = now.plusMillis(accessExpMs); // 예: 30분
 
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
-                .setSubject(kakaoEmail) // 이메일을 subject로 설정
+                .setClaims(Map.of("userId", userId))
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(expiration))
                 .signWith(secretKey)

--- a/src/main/java/com/hsp/fitu/service/AuthService.java
+++ b/src/main/java/com/hsp/fitu/service/AuthService.java
@@ -3,5 +3,5 @@ package com.hsp.fitu.service;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
-    void oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
+    boolean oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
 }


### PR DESCRIPTION
- 기존 회원인 경우 200, 신규 회원인 경우 201 응답으로 수정
- JWT에 이메일 대신 userId 포함하도록 변경