### PR TITLE
refactor: 인증 방식 AuthenticationPrincipal 기반으로 변경

### DIFF
--- a/src/main/java/com/hsp/fitu/controller/PhysicalInfoController.java
+++ b/src/main/java/com/hsp/fitu/controller/PhysicalInfoController.java
@@ -4,9 +4,11 @@ import com.hsp.fitu.dto.PhysicalInfoResponseDTO;
 import com.hsp.fitu.dto.PhysicalInfoUpdateRequestDTO;
 import com.hsp.fitu.dto.PhysicalInfoWeightHeightResponseDTO;
 import com.hsp.fitu.dto.PhysicalInfosRequestDTO;
+import com.hsp.fitu.jwt.CustomUserDetails;
 import com.hsp.fitu.service.PhysicalInfoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,18 +20,21 @@ import java.util.List;
 public class PhysicalInfoController {
     private final PhysicalInfoService physicalInfoService;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<PhysicalInfoResponseDTO> getPhysicsInfos(@PathVariable long userId) {
+    @GetMapping()
+    public ResponseEntity<PhysicalInfoResponseDTO> getPhysicsInfos(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
         return ResponseEntity.ok(physicalInfoService.getPhysicalInfo(userId));
     }
 
-    @GetMapping("/{userId}/muscle-bodyfat")
-    public ResponseEntity<List<PhysicalInfoWeightHeightResponseDTO>> getWeightsAndHeights(@PathVariable long userId, @RequestBody PhysicalInfosRequestDTO physicalInfosRequestDTO) {
+    @GetMapping("/muscle-bodyfat")
+    public ResponseEntity<List<PhysicalInfoWeightHeightResponseDTO>> getWeightsAndHeights(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody PhysicalInfosRequestDTO physicalInfosRequestDTO) {
+        Long userId = userDetails.getId();
         return ResponseEntity.ok(physicalInfoService.getMuscleAndBodyFat(userId, physicalInfosRequestDTO));
     }
 
-    @PostMapping("/{userId}")
-    public ResponseEntity<String> updatePhysicalInfo(@PathVariable long userId, @RequestBody PhysicalInfoUpdateRequestDTO physicalInfoUpdateRequestDTO) {
+    @PostMapping()
+    public ResponseEntity<String> updatePhysicalInfo(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody PhysicalInfoUpdateRequestDTO physicalInfoUpdateRequestDTO) {
+        Long userId = userDetails.getId();
         physicalInfoService.updatePhysicalInfo(userId, physicalInfoUpdateRequestDTO);
         return ResponseEntity.ok("physical info 업데이트 완료");
     }

--- a/src/main/java/com/hsp/fitu/controller/UserProfileController.java
+++ b/src/main/java/com/hsp/fitu/controller/UserProfileController.java
@@ -1,8 +1,10 @@
 package com.hsp.fitu.controller;
 
 import com.hsp.fitu.dto.UserProfileRequestDTO;
+import com.hsp.fitu.jwt.CustomUserDetails;
 import com.hsp.fitu.service.UserProfileService;
 import org.springframework.http.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,8 +19,9 @@ public class UserProfileController {
 
     @PostMapping("/profile")
     public ResponseEntity<String> inputProfile(
-            @RequestParam("userId") long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserProfileRequestDTO dto) {
+        Long userId = userDetails.getId();
         userProfileService.inputProfileOnce(userId, dto);
         return ResponseEntity.ok("추가정보 입력 완료");
     }

--- a/src/main/java/com/hsp/fitu/dto/BodyImageMainResponseDTO.java
+++ b/src/main/java/com/hsp/fitu/dto/BodyImageMainResponseDTO.java
@@ -2,9 +2,11 @@ package com.hsp.fitu.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
 @AllArgsConstructor
+@Getter
 public class BodyImageMainResponseDTO {
     private String imageUrl;
 }

--- a/src/main/java/com/hsp/fitu/jwt/CustomUserDetails.java
+++ b/src/main/java/com/hsp/fitu/jwt/CustomUserDetails.java
@@ -1,0 +1,21 @@
+package com.hsp.fitu.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private Long id;
+    private String username;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+}

--- a/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
@@ -1,10 +1,10 @@
 package com.hsp.fitu.jwt;
 
+import com.hsp.fitu.entity.enums.Role;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -25,13 +25,14 @@ public class JwtUtil {
         accessExpMs = access;
     }
 
-    public String createAccessToken(long userId) {
+    public String createAccessToken(long userId, Role role) {
         Instant now = Instant.now();
         Instant expiration = now.plusMillis(accessExpMs); // 예: 30분
 
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
-                .setClaims(Map.of("userId", userId))
+                .addClaims(Map.of("userId", userId,
+                        "role", role.toString()))
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(expiration))
                 .signWith(secretKey)

--- a/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
@@ -26,22 +26,19 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public LoginDTO oAuthLogin(String accessCode, HttpServletResponse httpServletResponse) {
         boolean isNewUser = false;
-        log.info("현재 적용된 DB URL: " + dbUrl);
         KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode);
         KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
         String kakaoEmail = kakaoProfile.getKakao_account().getEmail();
 
         UserEntity userEntity = userRepository.findByKakaoEmail(kakaoEmail)
                 .orElse(null);
-//                .orElseGet(() -> createNewUser(kakaoProfile));
 
         if (userEntity == null) {
             isNewUser = true;
-            log.warn("hi");
             userEntity = createNewUser(kakaoProfile);
         }
 
-        String token = jwtUtil.createAccessToken(userEntity.getId());
+        String token = jwtUtil.createAccessToken(userEntity.getId(), userEntity.getRole());
         httpServletResponse.setHeader("Authorization", "Bearer " + token);
 
         return LoginDTO.builder()

--- a/src/main/java/com/hsp/fitu/service/BodyImageServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/BodyImageServiceImpl.java
@@ -24,7 +24,6 @@ public class BodyImageServiceImpl implements BodyImageService {
 
     @Override
     public List<BodyImageEntity> getBodyImages(long userId) {
-        log.info("userID:" + userId);
 
         return bodyImageRepository.findByUserIdOrderByRecordedAtDesc(userId);
     }


### PR DESCRIPTION
- userId PathVariable 제거
- @AuthenticationPrincipal로 사용자 정보 추출하도록 수정
- JwtAuthenticationFilter에서 CustomUserDetails 생성 및 SecurityContext 저장
- JwtUtil에 role 클레임 추가