### PR TITLE
refactor: BodyImage 기능 delete 요청 방식 및 관련 로직 수정

### DIFF
--- a/src/main/java/com/hsp/fitu/controller/BodyImageController.java
+++ b/src/main/java/com/hsp/fitu/controller/BodyImageController.java
@@ -1,5 +1,6 @@
 package com.hsp.fitu.controller;
 
+import com.hsp.fitu.dto.BodyImageDeleteRequestDTO;
 import com.hsp.fitu.dto.BodyImageMainResponseDTO;
 import com.hsp.fitu.dto.BodyImageUploadResponseDTO;
 import com.hsp.fitu.entity.BodyImageEntity;
@@ -47,8 +48,8 @@ public class BodyImageController {
     }
 
     @DeleteMapping()
-    public ResponseEntity<?> s3delete(@RequestParam String addr) {
-        s3ImageService.deleteImageFromS3(addr);
+    public ResponseEntity<?> s3delete(@RequestBody BodyImageDeleteRequestDTO dto) {
+        s3ImageService.deleteImageFromS3(dto);
         return ResponseEntity.ok("body image 삭제 완료");
     }
 }

--- a/src/main/java/com/hsp/fitu/dto/BodyImageDeleteRequestDTO.java
+++ b/src/main/java/com/hsp/fitu/dto/BodyImageDeleteRequestDTO.java
@@ -1,0 +1,10 @@
+package com.hsp.fitu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BodyImageDeleteRequestDTO {
+    private String imageUrl;
+}

--- a/src/main/java/com/hsp/fitu/entity/BodyImageEntity.java
+++ b/src/main/java/com/hsp/fitu/entity/BodyImageEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class BodyImageEntity {
     @Id
     private long id;

--- a/src/main/java/com/hsp/fitu/repository/BodyImageRepository.java
+++ b/src/main/java/com/hsp/fitu/repository/BodyImageRepository.java
@@ -2,17 +2,21 @@ package com.hsp.fitu.repository;
 
 import com.hsp.fitu.entity.BodyImageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 public interface BodyImageRepository extends JpaRepository<BodyImageEntity, Long> {
 
-    @Query("SELECT b.url FROM BodyImageEntity b WHERE b.userId = :userId ORDER BY b.recordedAt DESC")
-    String findMainImageUrlByUserIdAndOOrderByRecordedAtDesc(long userId);
+    BodyImageEntity findFirstUrlByUserIdOrderByRecordedAtDesc(long userId);
 
+    @Modifying
+    @Query("DELETE FROM BodyImageEntity b WHERE b.url = :imageUrl")
+    @Transactional
     void deleteByUrl(String imageUrl);
 
     List<BodyImageEntity> findByUserIdOrderByRecordedAtDesc(long userId);

--- a/src/main/java/com/hsp/fitu/service/BodyImageServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/BodyImageServiceImpl.java
@@ -17,9 +17,9 @@ public class BodyImageServiceImpl implements BodyImageService {
 
     @Override
     public BodyImageMainResponseDTO getMainBodyImage(long userId) {
-        String imageUrl = bodyImageRepository.findMainImageUrlByUserIdAndOOrderByRecordedAtDesc(userId);
-        BodyImageMainResponseDTO bodyImageMainResponseDTO = new BodyImageMainResponseDTO(imageUrl);
-        return bodyImageMainResponseDTO;
+        BodyImageEntity entity = bodyImageRepository.findFirstUrlByUserIdOrderByRecordedAtDesc(userId);
+        String imageUrl = entity.getUrl();
+        return new BodyImageMainResponseDTO(imageUrl);
     }
 
     @Override

--- a/src/main/java/com/hsp/fitu/service/S3ImageService.java
+++ b/src/main/java/com/hsp/fitu/service/S3ImageService.java
@@ -1,8 +1,9 @@
 package com.hsp.fitu.service;
 
+import com.hsp.fitu.dto.BodyImageDeleteRequestDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface S3ImageService {
     String upload(MultipartFile image, long userId);
-    void deleteImageFromS3(String imageUrl);
+    void deleteImageFromS3(BodyImageDeleteRequestDTO imageUrl);
 }

--- a/src/main/java/com/hsp/fitu/service/S3ImageServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/S3ImageServiceImpl.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
+import com.hsp.fitu.dto.BodyImageDeleteRequestDTO;
 import com.hsp.fitu.entity.BodyImageEntity;
 import com.hsp.fitu.error.customExceptions.EmptyFileException;
 import com.hsp.fitu.error.ErrorCode;
@@ -110,7 +111,8 @@ public class S3ImageServiceImpl implements S3ImageService {
     }
 
     @Override
-    public void deleteImageFromS3(String imageUrl) {
+    public void deleteImageFromS3(BodyImageDeleteRequestDTO dto) {
+        String imageUrl = dto.getImageUrl();
         String key = getKeyFromImageAddress(imageUrl);
         try {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));


### PR DESCRIPTION
- @RequestParam → @RequestBody 방식으로 변경하여 BodyImageDeleteRequestDTO 추가
- S3ImageService, S3ImageServiceImpl delete 메서드 시그니처 수정
- BodyImageRepository delete 쿼리 수정
- BodyImageServiceImpl main-image 조회 방식 수정