### PR TITLE
feat: 소셜 로그인 후 추가정보 입력으로 사용자 역할 설정 기능 구현

### DIFF
--- a/src/main/java/com/hsp/fitu/controller/UserProfileController.java
+++ b/src/main/java/com/hsp/fitu/controller/UserProfileController.java
@@ -1,28 +1,31 @@
 package com.hsp.fitu.controller;
 
+import com.hsp.fitu.dto.AdditionalInfoResponseDTO;
 import com.hsp.fitu.dto.UserProfileRequestDTO;
 import com.hsp.fitu.jwt.CustomUserDetails;
 import com.hsp.fitu.service.UserProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/user")
+@RequiredArgsConstructor
+@Slf4j
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
 
-    public UserProfileController(UserProfileService userProfileService) {
-        this.userProfileService = userProfileService;
-    }
-
     @PostMapping("/profile")
-    public ResponseEntity<String> inputProfile(
+    public ResponseEntity<AdditionalInfoResponseDTO> inputProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserProfileRequestDTO dto) {
         Long userId = userDetails.getId();
-        userProfileService.inputProfileOnce(userId, dto);
-        return ResponseEntity.ok("추가정보 입력 완료");
+        log.info("userId: " + userId);
+
+        AdditionalInfoResponseDTO additionalInfoResponseDTO = userProfileService.inputProfileOnce(userId, dto);
+        return ResponseEntity.ok(additionalInfoResponseDTO);
     }
 }

--- a/src/main/java/com/hsp/fitu/dto/AdditionalInfoResponseDTO.java
+++ b/src/main/java/com/hsp/fitu/dto/AdditionalInfoResponseDTO.java
@@ -1,0 +1,10 @@
+package com.hsp.fitu.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AdditionalInfoResponseDTO {
+    private String token;
+}

--- a/src/main/java/com/hsp/fitu/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -66,7 +67,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String role = (String) claims.get("role");
 
         // SecurityContext 에 추가할 Authentication 인스턴스 생성
-        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        if (role != null && !role.isBlank()) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+        }
+
+//        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
         CustomUserDetails userDetails = new CustomUserDetails(userId, claims.getSubject(), authorities);
 
         UsernamePasswordAuthentication authentication = new UsernamePasswordAuthentication(userDetails, null, authorities);

--- a/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,7 @@ import java.util.Date;
 import java.util.Map;
 
 @Component
+@Slf4j
 public class JwtUtil {
     private final SecretKey secretKey;
     private final Long accessExpMs;
@@ -34,10 +36,17 @@ public class JwtUtil {
         Instant now = Instant.now();
         Instant expiration = now.plusMillis(accessExpMs); // 예: 30분
 
+        // claim
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId);
+        log.info("userId2 : " + userId);
+        if (role != null) {
+            claims.put("role", role.toString());
+        }
+
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
-                .addClaims(Map.of("userId", userId,
-                        "role", role.toString()))
+                .addClaims(claims)
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(expiration))
                 .signWith(secretKey)

--- a/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
@@ -38,14 +38,21 @@ public class AuthServiceImpl implements AuthService {
 
         UserEntity userEntity = userRepository.findByKakaoEmail(kakaoEmail)
                 .orElse(null);
+        Role role;
 
+        // new user 인 경우
         if (userEntity == null) {
             isNewUser = true;
             userEntity = createNewUser(kakaoProfile);
+            role = null;
+            log.info("userId4: " + userEntity.getId());
+        } else {
+            role = userEntity.getRole();
         }
 
         Long userId = userEntity.getId();
-        String accessToken = jwtUtil.createAccessToken(userId, userEntity.getRole());
+        log.info("userId3: " + userId);
+        String accessToken = jwtUtil.createAccessToken(userId, role);
         String refreshToken = jwtUtil.createRefreshToken(userId);
         httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
 
@@ -81,10 +88,11 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private UserEntity createNewUser(KakaoDTO.KakaoProfile kakaoProfile) {
+        String kakaoEmail = kakaoProfile.getKakao_account().getEmail();
         UserEntity newUser = UserEntity.builder()
-                .kakaoEmail(kakaoProfile.getKakao_account().getEmail())
+                .kakaoEmail(kakaoEmail)
                 .build();
         userRepository.save(newUser);
-        return newUser;
+        return userRepository.findByKakaoEmail(kakaoEmail).orElse(null);
     }
 }

--- a/src/main/java/com/hsp/fitu/service/UserProfileService.java
+++ b/src/main/java/com/hsp/fitu/service/UserProfileService.java
@@ -1,7 +1,8 @@
 package com.hsp.fitu.service;
 
+import com.hsp.fitu.dto.AdditionalInfoResponseDTO;
 import com.hsp.fitu.dto.UserProfileRequestDTO;
 
 public interface UserProfileService {
-    void inputProfileOnce(long userId, UserProfileRequestDTO dto);
+    AdditionalInfoResponseDTO inputProfileOnce(long userId, UserProfileRequestDTO dto);
 }


### PR DESCRIPTION
- 소셜 로그인 시 역할 없이 임시 토큰 발급
- 추가정보 입력 API 구현 (닉네임, 역할)
- 역할 저장 후 정식 JWT 재발급
- 임시 토큰에서도 인증 유지되도록 JWT 필터 수정
- 권한 없는 경우에도 인증되도록 SecurityContext 설정 처리