### PR TITLE
[backend] feat: GlobalExceptionHandler 예외 대응 범위 확장 및 에러 코드 개선

### DIFF
--- a/src/main/java/com/hsp/fitu/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/hsp/fitu/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.hsp.fitu.error;
 import com.hsp.fitu.error.customExceptions.EmptyFileException;
 import com.hsp.fitu.error.customExceptions.InvalidImageFileException;
 import com.hsp.fitu.error.customExceptions.S3UploadFailException;
+import com.hsp.fitu.error.customExceptions.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,66 +18,98 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-@RestControllerAdvice   // 모든 rest 컨트롤러에서 발생하는 exception 처리
-// exception 발생 시 전역으로 처리할 exception handler
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)    // 유효성 검사 실패시 발생하는 예외
+    // 유효성 검사 실패시 발생하는 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        log.warn("Validation error occurred for request: {}", ex.getParameter().getParameterName(), ex);    // 유효성 검사 오류가 발생한 매개변수의 이름
+        log.warn("Validation error occurred for request: {}", ex.getParameter().getParameterName(), ex);
 
-        // 유효성 검사에서 실패한 필드와 에러 메시지 추출
         List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
         Map<String, String> errorMap = new HashMap<>();
 
-        // 필드 이름과 에러 메시지를 Map에 담기
         for (FieldError fieldError : fieldErrors) {
             errorMap.put(fieldError.getField(), fieldError.getDefaultMessage());
         }
 
-        // ErrorResponse 생성 및 필드별 오류 설정
-        ErrorResponse response = new ErrorResponse(ErrorCode.Method_Argument_Not_Valid);
-        response.setFieldErrors(errorMap);  // 필드별 오류를 추가
+        ErrorResponse response = new ErrorResponse(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
+        response.setFieldErrors(errorMap);
 
-        // 기본 예외 처리 (위에서 처리되지 않은 경우)
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // 리소스 없음 예외 처리
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException ex) {
-        log.warn("handleNoResourceFoundException", ex);
-        ErrorResponse response = new ErrorResponse(ErrorCode.Method_Argument_Not_Valid);
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        log.warn("Resource not found: {}", ex.getMessage(), ex);
+        ErrorResponse response = new ErrorResponse(ErrorCode.NOT_FOUND);
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
+    // 잘못된 인수 예외 처리
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
-        log.warn("handleIllegalArgumentException", ex);
-        ErrorResponse response = new ErrorResponse(ErrorCode.Method_Argument_Not_Valid);
+        log.warn("Illegal argument provided: {}", ex.getMessage(), ex);
+        ErrorResponse response = new ErrorResponse(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // 런타임 예외 처리 (구체적인 메시지가 있는 경우)
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+        log.error("Runtime exception occurred: {}", ex.getMessage(), ex);
+
+        // 메시지에 따라 적절한 에러 코드 선택
+        ErrorCode errorCode;
+        if (ex.getMessage().contains("운동을 찾을 수 없습니다")) {
+            errorCode = ErrorCode.WORKOUT_NOT_FOUND;
+        } else if (ex.getMessage().contains("운동 정보 없음")) {
+            errorCode = ErrorCode.WORKOUT_NOT_FOUND;
+        } else {
+            errorCode = ErrorCode.INTER_SERVER_ERROR;
+        }
+
+        ErrorResponse response = new ErrorResponse(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    // 빈 파일 에외 처리
     @ExceptionHandler(EmptyFileException.class)
     public ResponseEntity<ErrorResponse> handleEmptyFileException(EmptyFileException ex) {
+        log.warn("Empty file exception: {}", ex.getMessage(), ex);
         ErrorResponse response = new ErrorResponse(ErrorCode.EMPTY_FILE);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // 유효하지 않은 이미지 파일 예외 처리
     @ExceptionHandler(InvalidImageFileException.class)
     public ResponseEntity<ErrorResponse> handleInvalidImageFileException(InvalidImageFileException ex) {
+        log.warn("Invalid image file exception: {}", ex.getMessage(), ex);
         ErrorResponse response = new ErrorResponse(ErrorCode.INVALID_FILE_EXTENSION);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // S3 업로드 실패 예외 처리
     @ExceptionHandler(S3UploadFailException.class)
     public ResponseEntity<ErrorResponse> handleS3UploadFailException(S3UploadFailException ex) {
+        log.warn("S3 upload failed: {}", ex.getMessage(), ex);
         ErrorResponse response = new ErrorResponse(ErrorCode.S3_UPLOAD_FAILED);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // 인증 실패 예외 처리
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException ex) {
+        log.warn("Unauthorized access: {}", ex.getMessage(), ex);
+        ErrorResponse response = new ErrorResponse(ErrorCode.UNAUTHORIZED);
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    // 기타 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        log.warn("handleException", ex);
+        log.error("Unexpected exception occurred: {}", ex.getMessage(), ex);
         ErrorResponse response = new ErrorResponse(ErrorCode.INTER_SERVER_ERROR);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
## 🔧 작업 내용

- `GlobalExceptionHandler`의 전반적인 예외 처리 로직 개선 및 범위 확장
- 다음과 같은 예외 케이스를 새로 핸들링하도록 추가:
  - `RuntimeException` → 메시지에 따라 `WORKOUT_NOT_FOUND` 등으로 매핑
  - `UnauthorizedException` → `ErrorCode.UNAUTHORIZED`로 매핑
- 기존 `NoResourceFoundException`의 에러코드 `METHOD_ARGUMENT_NOT_VALID` → `NOT_FOUND`로 수정
- 각 예외 핸들러에서 로그 메시지를 더 명확하게 출력 (`ex.getMessage()` 포함)
- 전체적으로 `ErrorCode` 및 `HttpStatus` 응답의 일관성 강화

## 📁 변경 파일

- `GlobalExceptionHandler.java`

## 🎯 목적

- 다양한 예외 상황에 대한 보다 세밀한 대응
- 클라이언트에게 명확한 에러 메시지 및 HTTP 상태 코드 제공
- 유지보수성 높은 에러 구조 확립