### PR TITLE
[backend] refactor: UnauthorizedException 생성자 오버로딩 및 에러코드 게터 추가

### DIFF
--- a/src/main/java/com/hsp/fitu/error/customExceptions/UnauthorizedException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/UnauthorizedException.java
@@ -1,11 +1,19 @@
 package com.hsp.fitu.error.customExceptions;
 
 import com.hsp.fitu.error.ErrorCode;
+import lombok.Getter;
 
-public class UnauthorizedException extends RuntimeException{
+@Getter
+public class UnauthorizedException extends RuntimeException {
     private ErrorCode errorCode;
-    public UnauthorizedException(String message, ErrorCode errorCode){
+
+    public UnauthorizedException(String message, ErrorCode errorCode) {
         super(message);
+        this.errorCode = errorCode;
+    }
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 }


### PR DESCRIPTION
## 🔧 작업 내용

- `UnauthorizedException`에 `ErrorCode`만 전달받는 생성자 오버로딩 추가
  - `super(errorCode.getMessage())`를 통해 메시지 자동 설정 가능
- `lombok.Getter` 적용으로 `errorCode` 필드 접근 가능하도록 수정
- 기존 message + errorCode 전달 방식은 그대로 유지하며 선택적 사용 가능

## 🎯 목적

- `UnauthorizedException`을 더 유연하게 생성할 수 있도록 구조 개선
- Exception 핸들링 시 코드 중복 감소 (`errorCode.getMessage()` 수동 작성 불필요)
- GlobalExceptionHandler 등에서 예외 처리 시 활용도 향상

## ✅ 예시 사용 방식

```java
throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
