### PR TITLE
[backend] feat: 사용자 및 운동 도메인의 NotFoundException 커스텀 예외 추가

### DIFF
--- a/src/main/java/com/hsp/fitu/error/customExceptions/UserNotFoundException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/UserNotFoundException.java
@@ -1,0 +1,19 @@
+package com.hsp.fitu.error.customExceptions;
+
+import com.hsp.fitu.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public UserNotFoundException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public UserNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/hsp/fitu/error/customExceptions/WorkoutNotFoundException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/WorkoutNotFoundException.java
@@ -1,0 +1,19 @@
+package com.hsp.fitu.error.customExceptions;
+
+import com.hsp.fitu.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class WorkoutNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public WorkoutNotFoundException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public WorkoutNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용

- `UserNotFoundException` 클래스 추가
- `WorkoutNotFoundException` 클래스 추가
- 두 예외 모두 `RuntimeException`을 상속하며 `ErrorCode` 기반 생성자 오버로딩 제공
  - `ErrorCode`만 전달하거나
  - `message + ErrorCode` 조합으로 생성 가능

## 📁 변경 파일

- `UserNotFoundException.java`
- `WorkoutNotFoundException.java`

## 🎯 목적

- 사용자 도메인 및 운동 도메인에서의 자원 미조회 상황을 명확히 분리 처리
- 전역 예외 핸들러(`GlobalExceptionHandler`)에서 도메인 기반 구체적 응답 메시지 구성 가능
- 예외 메시지와 상태 코드(ErrorCode)를 함께 관리하여 유지보수성 향상

## ✅ 예시 사용 방식

```java
throw new UserNotFoundException(ErrorCode.USER_NOT_FOUND);
throw new WorkoutNotFoundException("운동 정보 없음", ErrorCode.WORKOUT_NOT_FOUND);
