### PR TITLE
[backend] refactor: 커스텀 예외 구조 개선 및 Auth/S3/Workout 서비스 예외 처리 통일

### DIFF
--- a/src/main/java/com/hsp/fitu/error/customExceptions/EmptyFileException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/EmptyFileException.java
@@ -5,8 +5,7 @@ import com.hsp.fitu.error.ErrorCode;
 
 public class EmptyFileException extends RuntimeException{
     private ErrorCode errorCode;
-    public EmptyFileException(String message, ErrorCode errorCode){
-        super(message);
+    public EmptyFileException(ErrorCode errorCode){
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
@@ -75,7 +75,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public TokenResponseDTO reissue(String refreshToken) {
         if (!jwtUtil.validateToken(refreshToken)) {
-            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new UnauthorizedException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         Long userId = jwtUtil.getUserId(refreshToken);

--- a/src/main/java/com/hsp/fitu/service/S3ImageServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/S3ImageServiceImpl.java
@@ -45,7 +45,7 @@ public class S3ImageServiceImpl implements S3ImageService {
     @Override
     public String upload(MultipartFile image, long userId) {
         if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
         }
 
         String imageUrl = this.uploadImage(image, "body-image");
@@ -63,21 +63,21 @@ public class S3ImageServiceImpl implements S3ImageService {
         try {
             return this.uploadImageToS3(image, folder);
         } catch (IOException e) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
         }
     }
 
     private void validateImageFileExtention(String filename) {
         int lastDotIndex = filename.lastIndexOf(".");
         if (lastDotIndex == -1) {
-            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE.getMessage(), ErrorCode.INVALID_IMAGE_FILE);
+            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE);
         }
 
         String extention = filename.substring(lastDotIndex + 1).toLowerCase();
         List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
 
         if (!allowedExtentionList.contains(extention)) {
-            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE.getMessage(), ErrorCode.INVALID_IMAGE_FILE);
+            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE);
         }
     }
 
@@ -119,7 +119,7 @@ public class S3ImageServiceImpl implements S3ImageService {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
             bodyImageRepository.deleteByUrl(imageUrl);
         } catch (Exception e) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
         }
     }
 
@@ -129,7 +129,7 @@ public class S3ImageServiceImpl implements S3ImageService {
             String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
             return decodingKey.substring(1); // 맨 앞의 '/' 제거
         } catch (MalformedURLException | UnsupportedEncodingException e) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
         }
     }
 }

--- a/src/main/java/com/hsp/fitu/service/WorkoutServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/WorkoutServiceImpl.java
@@ -7,6 +7,7 @@ import com.hsp.fitu.entity.enums.Workout;
 import com.hsp.fitu.entity.enums.WorkoutCategory;
 import com.hsp.fitu.error.ErrorCode;
 import com.hsp.fitu.error.customExceptions.EmptyFileException;
+import com.hsp.fitu.error.customExceptions.WorkoutNotFoundException;
 import com.hsp.fitu.repository.WorkoutCategoryRepository;
 import com.hsp.fitu.repository.WorkoutRepository;
 import lombok.RequiredArgsConstructor;
@@ -97,7 +98,7 @@ public class WorkoutServiceImpl implements WorkoutService {
                     WorkoutEntity entity = workoutRepository.findByName(workout);
 
                     if (entity == null) {
-                        throw new RuntimeException("운동을 찾을 수 없습니다: " + workout);
+                        throw new WorkoutNotFoundException("운동을 찾을 수 없습니다: " + workout, ErrorCode.WORKOUT_NOT_FOUND);
                     }
 
                     return WorkoutGifResponseDTO.builder()
@@ -112,10 +113,10 @@ public class WorkoutServiceImpl implements WorkoutService {
     @Override
     public void updateWorkoutImage(long workoutId, MultipartFile image) {
         WorkoutEntity workout = workoutRepository.findById(workoutId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid workout ID"));
+                .orElseThrow(() -> new WorkoutNotFoundException(ErrorCode.INVALID_WORKOUT_ID));
 
         if (image.isEmpty()) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
         }
 
         String newImageUrl = s3ImageService.uploadImage(image, "workouts/images/");
@@ -126,10 +127,10 @@ public class WorkoutServiceImpl implements WorkoutService {
     @Override
     public void updateWorkoutGif(long workoutId, MultipartFile gif) {
         WorkoutEntity workout = workoutRepository.findById(workoutId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid workout ID"));
+                .orElseThrow(() -> new WorkoutNotFoundException(ErrorCode.INVALID_WORKOUT_ID));
 
         if (gif.isEmpty()) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
         }
 
         String newGifUrl = s3ImageService.uploadImage(gif, "workouts/gifs/");


### PR DESCRIPTION
## 🔧 주요 변경 사항

### 📌 1. 커스텀 예외 클래스 개선
- `UnauthorizedException`, `EmptyFileException`, `WorkoutNotFoundException`에 `ErrorCode`만 전달 가능한 생성자 추가
- 불필요한 message 중복 제거 및 예외 생성 방식 간결화

### 📌 2. 서비스 레이어 예외 처리 방식 통일
- `AuthServiceImpl`: 잘못된 리프레시 토큰 → `ErrorCode.INVALID_REFRESH_TOKEN` 기반 예외로 수정
- `S3ImageServiceImpl`: `EmptyFileException` 생성 시 message 제거하고 `ErrorCode`만 전달
- `WorkoutServiceImpl`: 잘못된 workout ID 또는 존재하지 않는 workout → `WorkoutNotFoundException` 적용
  - `RuntimeException` → `WorkoutNotFoundException`으로 명확화
  - `IllegalArgumentException` → 도메인 기반 예외로 대체

## 📁 변경된 클래스

- `UnauthorizedException.java`
- `EmptyFileException.java`
- `WorkoutNotFoundException.java`
- `AuthServiceImpl.java`
- `S3ImageServiceImpl.java`
- `WorkoutServiceImpl.java`

## 🎯 목적

- 서비스 계층에서 발생하는 도메인별 예외를 명확하게 분리
- 불필요한 예외 메시지 중복 제거
- `GlobalExceptionHandler`에서의 일관된 예외 처리 체계 마련

## ✅ 예시 변경 전/후

```java
// 변경 전
throw new EmptyFileException(ErrorCode.EMPTY_FILE.getMessage(), ErrorCode.EMPTY_FILE);

// 변경 후
throw new EmptyFileException(ErrorCode.EMPTY_FILE);
