### PR TITLE
[backend] refactor: 커스텀 예외 생성자 message 제거 및 ErrorCode 기반으로 일원화

### DIFF
--- a/src/main/java/com/hsp/fitu/error/customExceptions/EmptyFileException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/EmptyFileException.java
@@ -2,10 +2,14 @@ package com.hsp.fitu.error.customExceptions;
 
 
 import com.hsp.fitu.error.ErrorCode;
+import lombok.Getter;
 
-public class EmptyFileException extends RuntimeException{
-    private ErrorCode errorCode;
-    public EmptyFileException(ErrorCode errorCode){
+@Getter
+public class EmptyFileException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public EmptyFileException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/hsp/fitu/error/customExceptions/InvalidImageFileException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/InvalidImageFileException.java
@@ -1,11 +1,14 @@
 package com.hsp.fitu.error.customExceptions;
 
 import com.hsp.fitu.error.ErrorCode;
+import lombok.Getter;
 
-public class InvalidImageFileException extends RuntimeException{
-    private ErrorCode errorCode;
-    public InvalidImageFileException(String message, ErrorCode errorCode){
-        super(message);
+@Getter
+public class InvalidImageFileException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public InvalidImageFileException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/hsp/fitu/error/customExceptions/S3UploadFailException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/S3UploadFailException.java
@@ -1,11 +1,14 @@
 package com.hsp.fitu.error.customExceptions;
 
 import com.hsp.fitu.error.ErrorCode;
+import lombok.Getter;
 
-public class S3UploadFailException extends RuntimeException{
-    private ErrorCode errorCode;
-    public S3UploadFailException(String message, ErrorCode errorCode){
-        super(message);
+@Getter
+public class S3UploadFailException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public S3UploadFailException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/hsp/fitu/error/customExceptions/UnauthorizedException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/UnauthorizedException.java
@@ -5,12 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class UnauthorizedException extends RuntimeException {
-    private ErrorCode errorCode;
-
-    public UnauthorizedException(String message, ErrorCode errorCode) {
-        super(message);
-        this.errorCode = errorCode;
-    }
+    private final ErrorCode errorCode;
 
     public UnauthorizedException(ErrorCode errorCode) {
         super(errorCode.getMessage());

--- a/src/main/java/com/hsp/fitu/error/customExceptions/UserNotFoundException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/UserNotFoundException.java
@@ -7,11 +7,6 @@ import lombok.Getter;
 public class UserNotFoundException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public UserNotFoundException(String message, ErrorCode errorCode) {
-        super(message);
-        this.errorCode = errorCode;
-    }
-
     public UserNotFoundException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;

--- a/src/main/java/com/hsp/fitu/error/customExceptions/WorkoutNotFoundException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/WorkoutNotFoundException.java
@@ -7,11 +7,6 @@ import lombok.Getter;
 public class WorkoutNotFoundException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public WorkoutNotFoundException(String message, ErrorCode errorCode) {
-        super(message);
-        this.errorCode = errorCode;
-    }
-
     public WorkoutNotFoundException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;


### PR DESCRIPTION
## 🔧 변경 내용

`RuntimeException`을 상속한 커스텀 예외 클래스들에 대해 다음과 같이 리팩토링을 진행했습니다:

### 📌 1. message 파라미터 제거
- 다음 예외 클래스에서 `String message, ErrorCode errorCode` 생성자를 제거하였습니다:
  - `EmptyFileException`
  - `InvalidImageFileException`
  - `S3UploadFailException`
  - `UnauthorizedException`
  - `UserNotFoundException`
  - `WorkoutNotFoundException`

### 📌 2. ErrorCode 기반 단일 생성자로 통일
- `super(errorCode.getMessage())` 형태로 예외 메시지는 `ErrorCode`에서 자동으로 가져오도록 처리
- `@Getter` 추가로 `errorCode` 접근 가능



## 🎯 작업 목적

- 커스텀 예외 생성 로직의 중복 제거
- 예외 메시지 관리의 일관성 유지 (`ErrorCode`에서 통합 관리)
- 서비스 계층에서 예외 생성 시 코드 간결화 및 실수 방지



## ✅ 예시 변경 전/후

```java
// 변경 전
throw new S3UploadFailException("업로드 실패", ErrorCode.S3_UPLOAD_FAILED);

// 변경 후
throw new S3UploadFailException(ErrorCode.S3_UPLOAD_FAILED);
