### PR TITLE
[backend] feat: GlobalExceptionHandler에 사용자 및 운동 도메인 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/hsp/fitu/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/hsp/fitu/error/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.hsp.fitu.error;
 
-import com.hsp.fitu.error.customExceptions.EmptyFileException;
-import com.hsp.fitu.error.customExceptions.InvalidImageFileException;
-import com.hsp.fitu.error.customExceptions.S3UploadFailException;
-import com.hsp.fitu.error.customExceptions.UnauthorizedException;
+import com.hsp.fitu.error.customExceptions.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -104,6 +101,22 @@ public class GlobalExceptionHandler {
         log.warn("Unauthorized access: {}", ex.getMessage(), ex);
         ErrorResponse response = new ErrorResponse(ErrorCode.UNAUTHORIZED);
         return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    // 운동 관련 예외 처리
+    @ExceptionHandler(WorkoutNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleWorkoutNotFoundException(WorkoutNotFoundException ex) {
+        log.warn("Workout not found: {}", ex.getMessage(), ex);
+        ErrorResponse response = new ErrorResponse(ex.getErrorCode());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getStatus()));
+    }
+
+    // 사용자 관련 예외 처리
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException ex) {
+        log.warn("User not found: {}", ex.getMessage(), ex);
+        ErrorResponse response = new ErrorResponse(ex.getErrorCode());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getStatus()));
     }
 
     // 기타 예외 처리


### PR DESCRIPTION
## 🔧 변경 내용

`GlobalExceptionHandler`에 다음 도메인별 커스텀 예외에 대한 핸들러를 추가했습니다:

### ✅ 추가된 예외 처리
- `WorkoutNotFoundException`
- `UserNotFoundException`

### 📌 상세 처리 방식
- 각각 `ErrorCode`를 기반으로 `ErrorResponse`를 생성하여 클라이언트에게 응답
- 로그 메시지에는 `ex.getMessage()` 포함하여 디버깅에 용이하도록 설정
- 기존 `RuntimeException` 핸들러에서 메시지 기반 분기(contains)를 제거하고 명시적인 타입 기반 처리로 전환 가능성 열어둠



## 🎯 목적

- 도메인별로 명확한 예외 응답 구조 확보
- 향후 `PostNotFoundException`, `FriendNotFoundException` 등 추가할 때 쉽게 확장 가능
- 공통 핸들러의 책임을 분산시켜 코드 가독성과 유지보수성 개선



## 📁 변경 파일

- `GlobalExceptionHandler.java`

