### PR TITLE
[backend] refactor: ErrorResponse에 타임스탬프 필드 추가

### DIFF
--- a/src/main/java/com/hsp/fitu/error/ErrorResponse.java
+++ b/src/main/java/com/hsp/fitu/error/ErrorResponse.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class ErrorResponse {
     private int status;
     private String message;
     private String code;
+    private LocalDateTime timestamp;
     // 필드별 오류
     @Setter
     private Map<String, String> fieldErrors;
@@ -21,6 +23,6 @@ public class ErrorResponse {
         this.status = errorCode.getStatus();
         this.message = errorCode.getMessage();
         this.code = errorCode.getErrorCode();
+        this.timestamp = LocalDateTime.now();
     }
-
 }


### PR DESCRIPTION
## 🔧 변경 내용

- `ErrorResponse` 클래스에 `timestamp: LocalDateTime` 필드를 추가
- 예외 발생 시 응답 본문에 오류 발생 시각을 포함하도록 구성
- 생성자 내부에서 `this.timestamp = LocalDateTime.now();`로 자동 설정



## 🎯 목적

- 클라이언트 측에서 예외 발생 시간 확인 가능
- 로그 확인 및 디버깅 시 타임라인 분석에 도움
- 표준화된 에러 응답 형식 확립



## 📁 변경 파일

- `ErrorResponse.java`



## ✅ 변경 후 응답 예시

```json
{
  "status": 400,
  "message": "요청한 리소스를 찾을 수 없습니다",
  "code": "COMMON-404",
  "timestamp": "2025-07-29T16:43:12.123456"
}
