### PR TITLE
[backend] refactor: S3ImageServiceImpl 예외별 ErrorCode 정확히 매핑하도록 수정

### DIFF
--- a/src/main/java/com/hsp/fitu/service/S3ImageServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/S3ImageServiceImpl.java
@@ -63,21 +63,21 @@ public class S3ImageServiceImpl implements S3ImageService {
         try {
             return this.uploadImageToS3(image, folder);
         } catch (IOException e) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.FILE_UPLOAD_FAILED);
         }
     }
 
     private void validateImageFileExtention(String filename) {
         int lastDotIndex = filename.lastIndexOf(".");
         if (lastDotIndex == -1) {
-            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE);
+            throw new EmptyFileException(ErrorCode.MISSING_FILE_EXTENSION);
         }
 
         String extention = filename.substring(lastDotIndex + 1).toLowerCase();
         List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
 
         if (!allowedExtentionList.contains(extention)) {
-            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE);
+            throw new EmptyFileException(ErrorCode.INVALID_FILE_EXTENSION);
         }
     }
 
@@ -102,7 +102,7 @@ public class S3ImageServiceImpl implements S3ImageService {
             amazonS3.putObject(putObjectRequest); // put image to S3
         } catch (Exception e) {
             log.error("S3 Upload failed: {}", e.getMessage(), e);
-            throw new S3UploadFailException(ErrorCode.S3_UPLOAD_FAILED.getMessage(), ErrorCode.S3_UPLOAD_FAILED);
+            throw new S3UploadFailException(ErrorCode.S3_UPLOAD_FAILED);
         } finally {
             byteArrayInputStream.close();
             is.close();
@@ -119,7 +119,7 @@ public class S3ImageServiceImpl implements S3ImageService {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
             bodyImageRepository.deleteByUrl(imageUrl);
         } catch (Exception e) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.S3_DELETE_FAILED);
         }
     }
 
@@ -129,7 +129,7 @@ public class S3ImageServiceImpl implements S3ImageService {
             String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
             return decodingKey.substring(1); // 맨 앞의 '/' 제거
         } catch (MalformedURLException | UnsupportedEncodingException e) {
-            throw new EmptyFileException(ErrorCode.EMPTY_FILE);
+            throw new EmptyFileException(ErrorCode.INVALID_IMAGE_FILE);
         }
     }
 }


### PR DESCRIPTION
## 🔧 변경 내용

`S3ImageServiceImpl` 클래스의 예외 처리 로직을 다음과 같이 개선했습니다:

### 상세 수정 사항
- `uploadImage` 내 `IOException` → `ErrorCode.FILE_UPLOAD_FAILED` 반환
- 이미지 확장자 검증(`validateImageFileExtention`)에서:
  - 확장자 누락 시 `ErrorCode.MISSING_FILE_EXTENSION`
  - 허용되지 않은 확장자일 경우 `ErrorCode.INVALID_FILE_EXTENSION`
- S3 업로드 실패 시 → `S3UploadFailException(ErrorCode.S3_UPLOAD_FAILED)`로 통일
- S3 삭제 실패 시 → `ErrorCode.S3_DELETE_FAILED` 반환
- `getKeyFromImageAddress`에서 URL 파싱 오류 발생 시 → `ErrorCode.INVALID_IMAGE_FILE`



## 🎯 목적

- 예외 상황에 맞는 정확한 `ErrorCode`를 매핑하여 클라이언트에 일관된 에러 응답 제공
- 로그 추적 및 디버깅 시 문제 원인 파악 용이성 향상
- 기존 `ErrorCode.EMPTY_FILE` 남용 문제 해결


## 📁 변경 파일

- `S3ImageServiceImpl.java`


