### PR TITLE
[backend] refactor: UserProfileService, WorkoutCalendarService에 커스텀 예외 적용

### DIFF
--- a/src/main/java/com/hsp/fitu/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/UserProfileServiceImpl.java
@@ -5,6 +5,8 @@ import com.hsp.fitu.dto.UserProfileRequestDTO;
 import com.hsp.fitu.entity.UserEntity;
 import com.hsp.fitu.entity.PhysicalInfoEntity;
 import com.hsp.fitu.entity.enums.Role;
+import com.hsp.fitu.error.ErrorCode;
+import com.hsp.fitu.error.customExceptions.UserNotFoundException;
 import com.hsp.fitu.jwt.JwtUtil;
 import com.hsp.fitu.repository.PhysicalInfoRepository;
 import com.hsp.fitu.repository.UserRepository;
@@ -25,7 +27,7 @@ public class UserProfileServiceImpl implements UserProfileService {
     @Override
     public AdditionalInfoResponseDTO inputProfileOnce(long userId, UserProfileRequestDTO dto) {
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         // UserEntity(gender) 수정
         Role role = dto.getRole();

--- a/src/main/java/com/hsp/fitu/service/WorkoutCalendarServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/WorkoutCalendarServiceImpl.java
@@ -5,6 +5,8 @@ import com.hsp.fitu.dto.WorkoutCalendarDetailDTO;
 import com.hsp.fitu.entity.WorkoutDetailLogEntity;
 import com.hsp.fitu.entity.WorkoutEntity;
 import com.hsp.fitu.entity.WorkoutLogEntity;
+import com.hsp.fitu.error.ErrorCode;
+import com.hsp.fitu.error.customExceptions.WorkoutNotFoundException;
 import com.hsp.fitu.repository.WorkoutDetailLogRepository;
 import com.hsp.fitu.repository.WorkoutLogRepository;
 import com.hsp.fitu.repository.WorkoutRepository;
@@ -14,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-//import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +45,7 @@ public class WorkoutCalendarServiceImpl implements WorkoutCalendarService {
 
             List<WorkoutCalendarDetailDTO> detailDTOs = details.stream().map(d -> {
                 WorkoutEntity workoutEntity = workoutRepository.findById(d.getWorkoutId())
-                        .orElseThrow(() -> new RuntimeException("운동 정보 없음"));
+                        .orElseThrow(() -> new WorkoutNotFoundException(ErrorCode.WORKOUT_NOT_FOUND));
 
                 return new WorkoutCalendarDetailDTO(
                         workoutEntity.getName(),


### PR DESCRIPTION
## 🔧 변경 내용

서비스 계층에서 발생하는 일반적인 예외(`IllegalArgumentException`, `RuntimeException`)를 
도메인별 커스텀 예외(`UserNotFoundException`, `WorkoutNotFoundException`)로 명확하게 분기 처리했습니다.

### ✅ 변경된 클래스

- `UserProfileServiceImpl`
  - 사용자 조회 실패 시 `IllegalArgumentException` → `UserNotFoundException(ErrorCode.USER_NOT_FOUND)`
- `WorkoutCalendarServiceImpl`
  - 운동 조회 실패 시 `RuntimeException("운동 정보 없음")` → `WorkoutNotFoundException(ErrorCode.WORKOUT_NOT_FOUND)`


## 🎯 목적

- 예외를 도메인 기반으로 명확하게 분리하여 `GlobalExceptionHandler`에서 세분화된 처리 가능
- 에러 응답의 코드 및 메시지 일관성 확보 (`ErrorCode` 기반)
- 유지보수성 향상 및 디버깅 용이


## 📁 변경 파일

- `UserProfileServiceImpl.java`
- `WorkoutCalendarServiceImpl.java`
