### PR TITLE
refactor: AmazonS3 기반 S3 로직을 S3Client(v2)로 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// aws
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'software.amazon.awssdk:s3:2.25.15'
+	implementation 'software.amazon.awssdk:auth:2.25.15'
 
 	// swagger
 //	implementation 'org springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'

--- a/src/main/java/com/hsp/fitu/config/S3Config.java
+++ b/src/main/java/com/hsp/fitu/config/S3Config.java
@@ -1,13 +1,12 @@
 package com.hsp.fitu.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class S3Config {
@@ -19,11 +18,14 @@ public class S3Config {
     private String region;
 
     @Bean
-    public AmazonS3 amazonS3() {
-        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
                 .build();
     }
 }

--- a/src/main/java/com/hsp/fitu/error/ErrorCode.java
+++ b/src/main/java/com/hsp/fitu/error/ErrorCode.java
@@ -2,7 +2,6 @@ package com.hsp.fitu.error;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.apache.http.HttpStatus;
 
 // 에러코드 정리
 @AllArgsConstructor


### PR DESCRIPTION
### 작업 개요
기존 AWS SDK v1 (`AmazonS3`) 기반의 S3 업로드/삭제 로직을 AWS SDK v2 (`S3Client`)로 마이그레이션했습니다.  
Spring Boot 3.x 환경에 맞게 호환성과 유지보수성을 개선했습니다.


### 주요 변경 사항

- `AmazonS3` → `S3Client`로 전환
- `PutObjectRequest`, `DeleteObjectRequest`, `RequestBody` 등 SDK v2 기반 코드로 리팩토링
- `S3Config`에서 `amazonS3()` → `s3Client()` Bean으로 변경
- URL 반환 방식 `amazonS3.getUrl(...)` → 직접 문자열 조합 방식으로 변경
- 사용하지 않게 된 `spring-cloud-starter-aws` 의존성 제거
- Gradle에 `software.amazon.awssdk:s3`, `auth` 의존성 추가

