### PR TITLE
feat: 친구 추가 로직에 사용할 에러코드 및 CustomException 정의

### DIFF
--- a/src/main/java/com/hsp/fitu/error/ErrorCode.java
+++ b/src/main/java/com/hsp/fitu/error/ErrorCode.java
@@ -24,8 +24,9 @@ public enum ErrorCode {
     DUPLICATE_USER(409, "USER-409", "이미 존재하는 사용자입니다"),
     DUPLICATE_EMAIL(409, "USER-409", "이미 등록된 이메일입니다. 다른 이메일을 사용해주세요"),
     INVALID_EMAIL_VERIFICATION_CODE(401, "USER-401", "유효하지 않은 이메일 인증 코드입니다"),
+    INVALID_FRIEND_CODE(404, "USER-404", "유효하지 않은 친구 코드입니다."),
     EMAIL_CODE_TIMEOUT(410, "USER-410", "이메일 인증 코드가 만료되었습니다"),
-    EMAIL_VERIFICATION_REQUEST_NOT_FOUND(400, "USER-400","이메일 인증 요청을 찾을 수 없습니다"),
+    EMAIL_VERIFICATION_REQUEST_NOT_FOUND(400, "USER-400", "이메일 인증 요청을 찾을 수 없습니다"),
 
     // 파일 업로드 에러 (FILE)
     EMPTY_FILE(400, "FILE-400", "파일이 비어있습니다"),
@@ -37,7 +38,7 @@ public enum ErrorCode {
     // S3 관련 에러 (S3)
     S3_UPLOAD_FAILED(500, "S3-500", "S3 업로드에 실패했습니다"),
     S3_DELETE_FAILED(500, "S3-500", "S3 삭제에 실패했습니다"),
-    
+
     // 운동 관련 에러 (WORKOUT)
     WORKOUT_NOT_FOUND(404, "WORKOUT-404", "운동을 찾을 수 없습니다"),
     WORKOUT_CALENDAR_NOT_FOUND(404, "WORKOUT-404", "운동 일정을 찾을 수 없습니다"),
@@ -45,7 +46,11 @@ public enum ErrorCode {
 
     // 피지컬 정보 관련 에러 (PHYSICAL)
     PHYSICAL_INFO_NOT_FOUND(404, "PHYSICAL-404", "신체 정보를 찾을 수 없습니다"),
-    INVALID_PHYSICAL_DATA(400, "PHYSICAL-400", "유효하지 않은 신체 데이터입니다.");
+    INVALID_PHYSICAL_DATA(400, "PHYSICAL-400", "유효하지 않은 신체 데이터입니다."),
+
+    // 친구 관계 관련 에러 (FRIENDSHIP)
+    FRIENDSHIP_ALREADY_EXISTS(409, "FRIENDSHIP-409", "이미 친구 관계입니다."),
+    INVALID_FRIEND_REQUEST(400, "FRIENDSHIP-400", "자기 자신은 친구로 추가할 수 없습니다.");
 
     private int status;
     private String errorCode;

--- a/src/main/java/com/hsp/fitu/error/customExceptions/CustomException.java
+++ b/src/main/java/com/hsp/fitu/error/customExceptions/CustomException.java
@@ -1,0 +1,12 @@
+package com.hsp.fitu.error.customExceptions;
+
+import com.hsp.fitu.error.ErrorCode;
+
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
### 개요
- 친구 추가 로직에서 발생할 수 있는 예외 상황을 처리하기 위해 에러코드를 확장하고,
  공통적으로 사용할 `CustomException` 클래스를 정의했습니다.

### 주요 변경 사항
- `ErrorCode`  
  - `INVALID_FRIEND_CODE`: 유효하지 않은 친구 코드
  - `FRIENDSHIP_ALREADY_EXISTS`: 이미 친구 관계인 경우
  - `INVALID_FRIEND_REQUEST`: 자기 자신을 친구로 추가하려는 경우
- `CustomException`  
  - `ErrorCode` 기반으로 예외를 던질 수 있도록 공통 예외 클래스 생성
