### PR TITLE
feat: FriendController에 친구 추가 API 구현

### DIFF
--- a/src/main/java/com/hsp/fitu/controller/FriendController.java
+++ b/src/main/java/com/hsp/fitu/controller/FriendController.java
@@ -1,0 +1,27 @@
+package com.hsp.fitu.controller;
+
+import com.hsp.fitu.dto.ApiResponseDTO;
+import com.hsp.fitu.dto.FriendAddRequestDTO;
+import com.hsp.fitu.jwt.CustomUserDetails;
+import com.hsp.fitu.service.FriendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/friend")
+public class FriendController {
+    private final FriendService friendService;
+
+    @PostMapping()
+    public ResponseEntity<ApiResponseDTO> addFriend(@RequestBody FriendAddRequestDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+
+        friendService.addFriend(requestDTO, userId);
+
+        return ResponseEntity.ok(new ApiResponseDTO("친구 추가가 완료되었습니다"));
+    }
+}

--- a/src/main/java/com/hsp/fitu/dto/ApiResponseDTO.java
+++ b/src/main/java/com/hsp/fitu/dto/ApiResponseDTO.java
@@ -1,8 +1,10 @@
 package com.hsp.fitu.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ApiResponseDTO {
     private String message;
 }

--- a/src/main/java/com/hsp/fitu/dto/FriendAddRequestDTO.java
+++ b/src/main/java/com/hsp/fitu/dto/FriendAddRequestDTO.java
@@ -1,0 +1,8 @@
+package com.hsp.fitu.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FriendAddRequestDTO {
+    private String code;
+}

--- a/src/main/java/com/hsp/fitu/service/FriendService.java
+++ b/src/main/java/com/hsp/fitu/service/FriendService.java
@@ -1,5 +1,7 @@
 package com.hsp.fitu.service;
 
+import com.hsp.fitu.dto.FriendAddRequestDTO;
+
 public interface FriendService {
-    void addFriend(String code, Long userId);
+    void addFriend(FriendAddRequestDTO code, Long userId);
 }

--- a/src/main/java/com/hsp/fitu/service/FriendServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/FriendServiceImpl.java
@@ -1,22 +1,26 @@
 package com.hsp.fitu.service;
 
+import com.hsp.fitu.dto.FriendAddRequestDTO;
 import com.hsp.fitu.entity.FriendshipEntity;
 import com.hsp.fitu.error.ErrorCode;
 import com.hsp.fitu.error.customExceptions.CustomException;
 import com.hsp.fitu.repository.FriendshipRepository;
 import com.hsp.fitu.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Service
 public class FriendServiceImpl implements FriendService {
     private final UserRepository userRepository;
     private final FriendshipRepository friendshipRepository;
 
     @Override
     @Transactional
-    public void addFriend(String code, Long userId) {
+    public void addFriend(FriendAddRequestDTO dto, Long userId) {
         // code로 사용자 id 검색
+        String code = dto.getCode();
         Long userIdToAdd = userRepository.findIdByFriendCode(code);
 
         Long userIdA = Math.min(userId, userIdToAdd);


### PR DESCRIPTION
### 개요
- 사용자로부터 친구 초대 코드를 입력받아 새로운 친구 관계를 생성하는 API를 `FriendController`에 구현했습니다.  

### 주요 변경 사항
- `FriendController`
  - `POST /friend` 엔드포인트 추가
  - `FriendAddRequestDTO` 요청을 받아 현재 로그인 사용자(`@AuthenticationPrincipal`) 기준으로 친구 추가 처리
  - 성공 시 `ApiResponseDTO` 반환

- `FriendAddRequestDTO`
  - 요청 본문에서 친구 초대 코드를 전달받기 위한 DTO 생성

- `ApiResponseDTO`
  - 응답 메시지를 전달하기 위한 생성자 추가 (`@AllArgsConstructor`)

- `FriendService`, `FriendServiceImpl`
  - 기존 `addFriend(String code, Long userId)` → `addFriend(FriendAddRequestDTO dto, Long userId)` 로 변경
  - 서비스 로직에서 `dto.getCode()` 로 초대 코드 조회 후 친구 추가 처리