### PR TITLE
fix: KakaoUtil 외부 API 파싱 실패 시 NPE 방지

### DIFF
--- a/src/main/java/com/hsp/fitu/error/ErrorCode.java
+++ b/src/main/java/com/hsp/fitu/error/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     // 공통 에러 (COMMON)
     NOT_FOUND(404, "COMMON-404", "요청한 리소스를 찾을 수 없습니다"),
     INTER_SERVER_ERROR(500, "COMMON-500", "서버 내부 오류가 발생했습니다"),
+    EXTERNAL_API_FAILED(502, "COMMON-502", "외부 API 호출에 실패했습니다"),
     METHOD_ARGUMENT_NOT_VALID(400, "COMMON-400", "잘못된 요청 파라미터입니다"),
 
     // 인증/인가 에러 (AUTH)

--- a/src/main/java/com/hsp/fitu/util/KakaoUtil.java
+++ b/src/main/java/com/hsp/fitu/util/KakaoUtil.java
@@ -2,16 +2,16 @@ package com.hsp.fitu.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
 import com.hsp.fitu.dto.KakaoDTO;
+import com.hsp.fitu.error.BusinessException;
+import com.hsp.fitu.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.Arrays;
 
 @Slf4j
 @Component
@@ -24,9 +24,15 @@ public class KakaoUtil {
     @Value(("${spring.kakao.auth.client_secret}"))
     private String clientSecret;
 
-    public KakaoDTO.OAuthToken requestToken(String accessCode) {
-        RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
 
+    public KakaoUtil(RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public KakaoDTO.OAuthToken requestToken(String accessCode) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.add("Accept", "application/json");
@@ -42,25 +48,20 @@ public class KakaoUtil {
 
         ResponseEntity<String> response = restTemplate.postForEntity("https://kauth.kakao.com/oauth/token", kakaoTokenRequest, String.class);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        KakaoDTO.OAuthToken oAuthToken = null;
         try {
-            oAuthToken = objectMapper.readValue(response.getBody(), KakaoDTO.OAuthToken.class);
+            return objectMapper.readValue(response.getBody(), KakaoDTO.OAuthToken.class);
         } catch (JsonProcessingException e) {
-            log.warn("failed");
-//            throw new AuthHandler(ErrorStatus._PARSING_ERROR);
+            log.error("카카오 토큰 응답 파싱 실패: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.EXTERNAL_API_FAILED);
         }
-        return oAuthToken;
     }
 
     public KakaoDTO.KakaoProfile requestProfile(KakaoDTO.OAuthToken oAuthToken) {
-        RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
-
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
         headers.add("Authorization","Bearer "+ oAuthToken.getAccess_token());
 
-        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest = new HttpEntity <>(headers);
+        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest = new HttpEntity<>(headers);
 
         ResponseEntity<String> response =
                 restTemplate.exchange(
@@ -68,18 +69,12 @@ public class KakaoUtil {
                 HttpMethod.GET,
                 kakaoProfileRequest,
                 String.class);
-        log.warn(response.toString());
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        KakaoDTO.KakaoProfile kakaoProfile = null;
         try {
-            kakaoProfile = objectMapper.readValue(response.getBody(), KakaoDTO.KakaoProfile.class);
+            return objectMapper.readValue(response.getBody(), KakaoDTO.KakaoProfile.class);
         } catch (JsonProcessingException e) {
-            log.info(Arrays.toString(e.getStackTrace()));
-            log.warn("failed request Profile");
-//            throw new AuthHandler(ErrorStatus._PARSING_ERROR);
+            log.error("카카오 프로필 응답 파싱 실패: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.EXTERNAL_API_FAILED);
         }
-
-        return kakaoProfile;
     }
 }


### PR DESCRIPTION
## Summary
- 카카오 OAuth 응답 JSON 파싱 실패 시 null 반환 → NPE 발생하던 구조를 즉시 예외 처리로 수정
- 외부 API 장애 전용 ErrorCode(`EXTERNAL_API_FAILED`, 502 Bad Gateway) 추가
- RestTemplate/ObjectMapper를 매번 `new` 생성에서 Bean 주입 방식으로 전환

## Test plan
- [ ] 카카오 로그인 정상 동작 확인
- [ ] 카카오 API 장애 시 502 응답 반환 확인
- [ ] RestTemplate Bean 주입 정상 동작 확인