### PR TITLE
feat: Refresh Token rotation, server-side revocation, reuse detection

### DIFF
--- a/src/main/java/com/hsp/fitu/config/JwtConfig.java
+++ b/src/main/java/com/hsp/fitu/config/JwtConfig.java
@@ -1,21 +1,22 @@
 package com.hsp.fitu.config;
 
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 
 @Configuration
 public class JwtConfig {
-    @Value("${jwt.secret}")
-    private String signingKey;
+    @Value("${jwt.access-secret}")
+    private String accessSecret;
 
     @Bean
+    @Qualifier("accessSecretKey")
     public SecretKey secretKey() {
-        return new SecretKeySpec(signingKey.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.HS256.getJcaName());
+        return Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/hsp/fitu/controller/AuthController.java
+++ b/src/main/java/com/hsp/fitu/controller/AuthController.java
@@ -5,8 +5,6 @@ import com.hsp.fitu.dto.TokenResponseDTO;
 import com.hsp.fitu.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,23 +32,18 @@ public class AuthController {
     }
 
     @GetMapping("/reissue")
-    public ResponseEntity<TokenResponseDTO> reissue(@CookieValue("refreshToken") String refreshToken) {
-        TokenResponseDTO tokenResponseDTO = authService.reissue(refreshToken);
-
+    public ResponseEntity<TokenResponseDTO> reissue(
+            @CookieValue("refreshToken") String refreshToken,
+            HttpServletResponse response) {
+        TokenResponseDTO tokenResponseDTO = authService.reissue(refreshToken, response);
         return ResponseEntity.ok(tokenResponseDTO);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
-        // 쿠키 삭제
-        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
-                .httpOnly(true)
-                .secure(false)
-                .path("/")
-                .maxAge(0)
-                .sameSite("None")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+    public ResponseEntity<String> logout(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response) {
+        authService.logout(refreshToken, response);
         return ResponseEntity.ok("Logout completed.");
     }
 }

--- a/src/main/java/com/hsp/fitu/controller/DevAuthController.java
+++ b/src/main/java/com/hsp/fitu/controller/DevAuthController.java
@@ -5,6 +5,7 @@ import com.hsp.fitu.dto.TokenResponseDTO;
 import com.hsp.fitu.entity.UserEntity;
 import com.hsp.fitu.entity.enums.Role;
 import com.hsp.fitu.jwt.JwtUtil;
+import com.hsp.fitu.jwt.RefreshTokenStore;
 import com.hsp.fitu.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @Profile("dev")
 @RestController
 @RequestMapping("/auth")
@@ -23,9 +26,13 @@ public class DevAuthController {
 
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenStore refreshTokenStore;
 
     @Value("${jwt.token.refresh-expiration-time}")
     private Long refreshExpMs;
+
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
 
     @PostMapping("/login/local")
     public ResponseEntity<TokenResponseDTO> localLogin(@RequestBody LocalLoginRequestDTO request, HttpServletResponse httpServletResponse) {
@@ -49,15 +56,19 @@ public class DevAuthController {
         Long universityId = userEntity.getUniversityId();
 
         String accessToken = jwtUtil.createAccessToken(userId, role, universityId);
-        String refreshToken = jwtUtil.createRefreshToken(userId);
+
+        String familyId = UUID.randomUUID().toString();
+        String jti = UUID.randomUUID().toString();
+        String refreshToken = jwtUtil.createRefreshToken(userId, familyId, jti);
+        refreshTokenStore.issue(userId, familyId, jti, refreshExpMs);
 
         httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(false)
+                .secure(cookieSecure)
                 .path("/")
-                .maxAge(refreshExpMs)
+                .maxAge(refreshExpMs / 1000)
                 .sameSite("Lax")
                 .build();
         httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());

--- a/src/main/java/com/hsp/fitu/error/ErrorCode.java
+++ b/src/main/java/com/hsp/fitu/error/ErrorCode.java
@@ -70,7 +70,13 @@ public enum ErrorCode {
     POST_WRITER_NOT_FOUND(404, "POST-404", "게시글 작성자를 찾을 수 없습니다"),
 
     // 채팅 관련 에러 (CHAT)
-    CHAT_MESSAGE_PUBLISH_FAILED(500, "CHAT-500", "채팅 메시지 발행 중 오류가 발생했습니다")
+    CHAT_MESSAGE_PUBLISH_FAILED(500, "CHAT-500", "채팅 메시지 발행 중 오류가 발생했습니다"),
+
+    // 서비스 가용성
+    SERVICE_UNAVAILABLE(503, "COMMON-503", "일시적으로 서비스를 이용할 수 없습니다"),
+
+    // 토큰 재사용 감지
+    REFRESH_TOKEN_REUSED(401, "AUTH-401-TOKEN-REUSE", "비정상적인 토큰 사용이 감지되었습니다")
     ;
 
     private int status;

--- a/src/main/java/com/hsp/fitu/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtAuthenticationFilter.java
@@ -49,6 +49,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (token != null) {
                 Claims claims = jwtTokenService.validateToken(token);
 
+                // RT가 AT로 사용되는 것을 방지 (키 분리 + type 이중 방어)
+                String type = claims.get("type", String.class);
+                if ("REFRESH".equals(type)) {
+                    throw new JwtException("Refresh token cannot be used as access token");
+                }
+
                 // SecurityContext 에 Authentication 인스턴스 추가
                 Authentication auth = jwtTokenService.createAuthentication(claims);
                 SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/hsp/fitu/jwt/JwtTokenService.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtTokenService.java
@@ -4,7 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
@@ -16,11 +16,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class JwtTokenService {
 
     private final TokenBlackListService tokenBlackListService;
     private final SecretKey secretKey;
+
+    public JwtTokenService(TokenBlackListService tokenBlackListService,
+                           @Qualifier("accessSecretKey") SecretKey secretKey) {
+        this.tokenBlackListService = tokenBlackListService;
+        this.secretKey = secretKey;
+    }
 
     public String extractTokenFromHeader(HttpServletRequest request) {
         String header = request.getHeader("Authorization");

--- a/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
+++ b/src/main/java/com/hsp/fitu/jwt/JwtUtil.java
@@ -21,18 +21,22 @@ import java.util.Map;
 @Slf4j
 @Component
 public class JwtUtil {
-    private final SecretKey secretKey;
+    private final SecretKey accessKey;
+    private final SecretKey refreshKey;
     private final Long accessExpMs;
     private final Long refreshExpMs;
     private final StringRedisTemplate redisTemplate;
 
     public JwtUtil(
-            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-secret}") String accessSecret,
+            @Value("${jwt.refresh-secret}") String refreshSecret,
             @Value("${jwt.token.access-expiration-time}") Long access,
-            @Value("${jwt.token.refresh-expiration-time}") Long refresh, StringRedisTemplate redisTemplate) {
-        secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-        accessExpMs = access;
-        refreshExpMs = refresh;
+            @Value("${jwt.token.refresh-expiration-time}") Long refresh,
+            StringRedisTemplate redisTemplate) {
+        this.accessKey = Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8));
+        this.refreshKey = Keys.hmacShaKeyFor(refreshSecret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpMs = access;
+        this.refreshExpMs = refresh;
         this.redisTemplate = redisTemplate;
     }
 
@@ -40,10 +44,10 @@ public class JwtUtil {
         Instant now = Instant.now();
         Instant expiration = now.plusMillis(accessExpMs);
 
-        // claim
         Claims claims = Jwts.claims();
         claims.put("userId", userId);
         claims.put("universityId", universityId);
+        claims.put("type", "ACCESS");
         if (role != null) {
             claims.put("role", role.toString());
         }
@@ -53,37 +57,41 @@ public class JwtUtil {
                 .addClaims(claims)
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(expiration))
-                .signWith(secretKey)
+                .signWith(accessKey)
                 .compact();
     }
 
-    public String createRefreshToken(long userId) {
+    public String createRefreshToken(long userId, String familyId, String jti) {
         Instant now = Instant.now();
         Instant expiration = now.plusMillis(refreshExpMs);
 
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
-                .addClaims(Map.of("userId", userId))
+                .setId(jti)
+                .addClaims(Map.of(
+                        "userId", userId,
+                        "type", "REFRESH",
+                        "fid", familyId
+                ))
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(expiration))
-                .signWith(secretKey)
+                .signWith(refreshKey)
                 .compact();
     }
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(token);
             return true;
         } catch (JwtException e) {
             return false;
         }
     }
 
-    // 2) 토큰 유효성 검증 + Claims 반환
     public Claims validateAndGetClaims(String token) throws Exception {
         try {
             return Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
+                    .setSigningKey(accessKey)
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
@@ -97,40 +105,60 @@ public class JwtUtil {
         } catch (UnsupportedJwtException e) {
             throw new BusinessException(ErrorCode.JWT_UNSUPPORTED);
         } catch (Exception e) {
-            log.error("JWT parsing error", e); // 서버 에러는 로그 남기기
+            log.error("JWT parsing error", e);
             throw new BusinessException(ErrorCode.INTER_SERVER_ERROR);
         }
     }
 
-    public Long getUserId(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+    public Claims parseRefreshClaims(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(refreshKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String type = claims.get("type", String.class);
+            if (!"REFRESH".equals(type)) {
+                throw new BusinessException(ErrorCode.UNAUTHORIZED);
+            }
+            return claims;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (JwtException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    public Long getUserId(Claims claims) {
         return claims.get("userId", Long.class);
     }
 
-    // token 무효화
+    public String getJti(Claims claims) {
+        return claims.getId();
+    }
+
+    public String getFamilyId(Claims claims) {
+        return claims.get("fid", String.class);
+    }
+
+    // token 무효화 (AT 블랙리스트용)
     public void invalidateToken(String token, String value) {
         long expiration = getExpiration(token.substring(7)).getTime();
         redisTemplate.opsForValue().set("blacklist: " + token, value, Duration.ofMillis(expiration));
     }
 
-    /** Claims에서 추출한 만료 시각(epoch millis)이 현재 시각을 지났는지 확인한다 */
     public boolean isExpired(long tokenExpiryMillis) {
         return System.currentTimeMillis() > tokenExpiryMillis;
     }
 
-    /** Claims에서 만료 시각을 epoch millis로 추출한다 */
     public long getExpiryMillis(Claims claims) {
         return claims.getExpiration().getTime();
     }
 
-    // jwt의 만료시간 get
     private Date getExpiration(String token) {
         Claims claims = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
+                .setSigningKey(accessKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/java/com/hsp/fitu/jwt/RefreshTokenStore.java
+++ b/src/main/java/com/hsp/fitu/jwt/RefreshTokenStore.java
@@ -1,0 +1,154 @@
+package com.hsp.fitu.jwt;
+
+import com.hsp.fitu.error.BusinessException;
+import com.hsp.fitu.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Refresh Token 화이트리스트 저장소 (Redis 기반).
+ *
+ * - 발급된 RT를 Redis에 등록하고, 재발급(rotation) 시 원자적으로 소비(consume)한다.
+ * - Reuse detection: 이미 소비된 토큰이 다시 사용되면 REUSE_DETECTED를 반환한다.
+ * - Family revocation: 토큰 가족 단위로 일괄 무효화한다.
+ * - Redis 장애 시 SERVICE_UNAVAILABLE 예외를 던진다 (fail-closed-but-soft).
+ */
+@Slf4j
+@Service
+public class RefreshTokenStore {
+
+    private final StringRedisTemplate redisTemplate;
+    private DefaultRedisScript<String> consumeScript;
+
+    // Redis key prefix: 개별 토큰 저장용
+    private static final String KEY_PREFIX = "rt:jti:";
+    // Redis key prefix: 가족 revoke 마커용
+    private static final String FAMILY_REVOKED_PREFIX = "rt:family:revoked:";
+
+    public RefreshTokenStore(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * Lua 스크립트 초기화.
+     * Redis 서버에서 원자적으로 실행되어 동시 요청 간 경쟁 상태를 방지한다.
+     *
+     * 스크립트 파라미터 매핑:
+     *   KEYS[1] = rt:jti:{oldJti}              — 소비할 토큰의 Redis key
+     *   KEYS[2] = rt:family:revoked:{familyId}  — 가족 revoke 마커 key
+     *   ARGV[1] = newJti                        — 새로 발급할 토큰의 ID
+     *   ARGV[2] = ttlMillis                     — TTL (밀리초)
+     *
+     * 반환값: OK | FAMILY_REVOKED | NOT_FOUND | REUSE_DETECTED
+     */
+    @PostConstruct
+    public void init() {
+        consumeScript = new DefaultRedisScript<>();
+        consumeScript.setResultType(String.class);
+        consumeScript.setScriptText(
+                // 1. 토큰 가족이 이미 revoke되었으면 즉시 거부
+                "if redis.call('EXISTS', KEYS[2]) == 1 then return 'FAMILY_REVOKED' end " +
+                // 2. 토큰 정보 조회
+                "local v = redis.call('GET', KEYS[1]) " +
+                // 3. 토큰이 Redis에 없으면 알 수 없는 토큰
+                "if not v then return 'NOT_FOUND' end " +
+                // 4. 이미 CONSUMED 상태면 재사용 감지 (탈취 의심)
+                "if string.find(v, ':CONSUMED:') then return 'REUSE_DETECTED' end " +
+                // 5. ACTIVE → CONSUMED:{newJti}로 상태 변경, TTL 유지
+                "local newVal = string.gsub(v, ':ACTIVE', '') .. ':CONSUMED:' .. ARGV[1] " +
+                "redis.call('SET', KEYS[1], newVal, 'PX', tonumber(ARGV[2])) " +
+                // 6. 성공
+                "return 'OK'"
+        );
+    }
+
+    /**
+     * 새 refresh token을 Redis에 등록한다.
+     * 값 형식: "{userId}:{familyId}:ACTIVE"
+     */
+    public void issue(long userId, String familyId, String jti, long ttlMs) {
+        try {
+            String key = KEY_PREFIX + jti;
+            String value = userId + ":" + familyId + ":ACTIVE";
+            redisTemplate.opsForValue().set(key, value, Duration.ofMillis(ttlMs));
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis connection failed during refresh token issue", e);
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * 기존 refresh token을 원자적으로 소비하고, 결과를 반환한다.
+     *
+     * - OK: 정상 소비됨. 이후 새 토큰을 issue()로 등록해야 함.
+     * - NOT_FOUND: 토큰이 Redis에 없음 (만료/위조/알 수 없음).
+     * - REUSE_DETECTED: 이미 소비된 토큰이 다시 사용됨 → 탈취 의심. 호출자가 revokeFamily()를 호출해야 함.
+     * - FAMILY_REVOKED: 이 토큰의 가족이 이미 무효화됨.
+     *
+     * Lua 스크립트로 실행되므로 동시에 같은 토큰으로 2개 요청이 와도
+     * 정확히 하나만 OK, 나머지는 REUSE_DETECTED를 반환한다.
+     */
+    public ConsumeOutcome consume(String oldJti, String familyId, String newJti, long ttlMs) {
+        try {
+            // KEYS: [rt:jti:{oldJti}, rt:family:revoked:{familyId}]
+            // ARGV: [newJti, ttlMs]
+            String result = redisTemplate.execute(
+                    consumeScript,
+                    List.of(KEY_PREFIX + oldJti, FAMILY_REVOKED_PREFIX + familyId),
+                    newJti,
+                    String.valueOf(ttlMs)
+            );
+            return ConsumeOutcome.valueOf(result);
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis connection failed during refresh token consume", e);
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * 토큰 가족 전체를 무효화한다.
+     * 이후 같은 familyId를 가진 모든 토큰의 consume/issue가 거부된다.
+     * 로그아웃 또는 reuse detection 시 호출.
+     */
+    public void revokeFamily(String familyId, long ttlMs) {
+        try {
+            redisTemplate.opsForValue().set(
+                    FAMILY_REVOKED_PREFIX + familyId,
+                    "1",
+                    Duration.ofMillis(ttlMs)
+            );
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis connection failed during family revocation", e);
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * 토큰 가족이 revoke되었는지 확인한다.
+     */
+    public boolean isFamilyRevoked(String familyId) {
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(FAMILY_REVOKED_PREFIX + familyId));
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis connection failed during family revocation check", e);
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * consume() 결과를 나타내는 열거형.
+     */
+    public enum ConsumeOutcome {
+        OK,
+        NOT_FOUND,
+        REUSE_DETECTED,
+        FAMILY_REVOKED
+    }
+}

--- a/src/main/java/com/hsp/fitu/service/AuthService.java
+++ b/src/main/java/com/hsp/fitu/service/AuthService.java
@@ -7,5 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
     LoginDTO oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
-    TokenResponseDTO reissue(String refreshToken);
+    TokenResponseDTO reissue(String refreshToken, HttpServletResponse response);
+    void logout(String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
+++ b/src/main/java/com/hsp/fitu/service/AuthServiceImpl.java
@@ -8,24 +8,34 @@ import com.hsp.fitu.entity.enums.Role;
 import com.hsp.fitu.error.BusinessException;
 import com.hsp.fitu.error.ErrorCode;
 import com.hsp.fitu.jwt.JwtUtil;
+import com.hsp.fitu.jwt.RefreshTokenStore;
 import com.hsp.fitu.repository.UserRepository;
 import com.hsp.fitu.util.KakaoUtil;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
     private final KakaoUtil kakaoUtil;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenStore refreshTokenStore;
 
     @Value("${jwt.token.refresh-expiration-time}")
     private Long refreshExpMs;
+
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
 
     @Override
     public LoginDTO oAuthLogin(String accessCode, HttpServletResponse httpServletResponse) {
@@ -51,18 +61,15 @@ public class AuthServiceImpl implements AuthService {
         Long universityId = userEntity.getUniversityId();
 
         String accessToken = jwtUtil.createAccessToken(userId, role, universityId);
-        String refreshToken = jwtUtil.createRefreshToken(userId);
-        httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
 
-        // refresh accessToken 쿠키에 저장
-        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
-                .httpOnly(true)
-                .secure(false)
-                .path("/")
-                .maxAge(refreshExpMs)
-                .sameSite("Lax")
-                .build();
-        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        // RT 발급: familyId와 jti를 생성하여 Redis에 등록
+        String familyId = UUID.randomUUID().toString();
+        String jti = UUID.randomUUID().toString();
+        String refreshToken = jwtUtil.createRefreshToken(userId, familyId, jti);
+        refreshTokenStore.issue(userId, familyId, jti, refreshExpMs);
+
+        httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
+        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, buildRefreshCookie(refreshToken).toString());
 
         return LoginDTO.builder()
                 .isNewUser(isNewUser)
@@ -72,24 +79,96 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public TokenResponseDTO reissue(String refreshToken) {
-        if (!jwtUtil.validateToken(refreshToken)) {
+    public TokenResponseDTO reissue(String refreshToken, HttpServletResponse response) {
+        // 1. RT 검증 (refreshKey로 서명/만료 확인 + type=REFRESH assertion)
+        Claims claims = jwtUtil.parseRefreshClaims(refreshToken);
+        String jti = jwtUtil.getJti(claims);
+        String familyId = jwtUtil.getFamilyId(claims);
+        Long userId = jwtUtil.getUserId(claims);
+
+        // 2. 레거시 토큰 거부 (jti/fid 없는 구버전)
+        if (jti == null || familyId == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
 
-        Long userId = jwtUtil.getUserId(refreshToken);
-        UserEntity userEntity = userRepository.findById(userId).orElse(null);
+        // 3. 원자적 consume: 기존 RT를 소비하고 결과에 따라 분기
+        String newJti = UUID.randomUUID().toString();
+        RefreshTokenStore.ConsumeOutcome outcome = refreshTokenStore.consume(jti, familyId, newJti, refreshExpMs);
 
+        switch (outcome) {
+            case OK -> { /* 정상 — 계속 진행 */ }
+            case NOT_FOUND, FAMILY_REVOKED -> throw new BusinessException(ErrorCode.UNAUTHORIZED);
+            case REUSE_DETECTED -> {
+                // 탈취 감지: 가족 전체 revoke 후 거부
+                log.warn("REFRESH_TOKEN_REUSE_DETECTED userId={} familyId={} consumedJti={}", userId, familyId, jti);
+                refreshTokenStore.revokeFamily(familyId, refreshExpMs);
+                throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSED);
+            }
+        }
+
+        // 4. 새 RT 발급 및 Redis 등록
+        refreshTokenStore.issue(userId, familyId, newJti, refreshExpMs);
+        String newRefreshToken = jwtUtil.createRefreshToken(userId, familyId, newJti);
+
+        // 5. 새 AT 발급
+        UserEntity userEntity = userRepository.findById(userId).orElse(null);
         Role role = null;
         Long universityId = null;
         if (userEntity != null) {
             role = userEntity.getRole();
             universityId = userEntity.getUniversityId();
         }
-
         String newAccessToken = jwtUtil.createAccessToken(userId, role, universityId);
+
+        // 6. 새 RT를 쿠키로 설정
+        response.addHeader(HttpHeaders.SET_COOKIE, buildRefreshCookie(newRefreshToken).toString());
+
         return TokenResponseDTO.builder()
                 .token(newAccessToken)
+                .build();
+    }
+
+    @Override
+    public void logout(String refreshToken, HttpServletResponse response) {
+        // RT가 없어도 쿠키 삭제 (멱등성)
+        if (refreshToken != null) {
+            try {
+                Claims claims = jwtUtil.parseRefreshClaims(refreshToken);
+                String familyId = jwtUtil.getFamilyId(claims);
+                if (familyId != null) {
+                    refreshTokenStore.revokeFamily(familyId, refreshExpMs);
+                }
+            } catch (BusinessException ignored) {
+                // 만료/잘못된 토큰이어도 쿠키는 삭제
+            }
+        }
+        // 쿠키 삭제
+        response.addHeader(HttpHeaders.SET_COOKIE, clearRefreshCookie().toString());
+    }
+
+    /**
+     * refresh token 쿠키 빌더. login/reissue에서 재사용.
+     */
+    private ResponseCookie buildRefreshCookie(String token) {
+        return ResponseCookie.from("refreshToken", token)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(refreshExpMs / 1000)
+                .sameSite("Lax")
+                .build();
+    }
+
+    /**
+     * refresh token 쿠키 삭제용 빌더. logout에서 사용.
+     */
+    private ResponseCookie clearRefreshCookie() {
+        return ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
                 .build();
     }
 


### PR DESCRIPTION
## Summary
- **JWT 시크릿 키 분리**: AT/RT 각각 별도 키로 서명하여 RT를 AT로 악용하는 공격 차단
- **RT 화이트리스트 (Redis)**: 발급된 RT를 서버 측에서 관리. Lua 스크립트로 원자적 consume 보장
- **RT rotation**: reissue 시마다 새 RT 발급 + 기존 RT를 CONSUMED로 마킹
- **Reuse detection**: 이미 소비된 RT가 재사용되면 토큰 가족 전체 revoke (탈취 대응)
- **Server-side revocation**: 로그아웃 시 토큰 가족 단위 무효화. 탈취된 RT도 즉시 차단
- **Redis 장애 대응 (fail-closed-but-soft)**: Redis 다운 시 reissue/login은 503, 기존 AT로 API는 정상 동작
- **쿠키 maxAge 버그 수정**: ms → 초 변환 누락 수정
- **레거시 토큰 마이그레이션**: jti/fid 없는 구버전 RT 즉시 거부 → 재로그인 강제

## Changed Files
| 파일 | 변경 |
|---|---|
| `jwt/RefreshTokenStore.java` | **신규** — Redis 화이트리스트 저장소 |
| `jwt/JwtUtil.java` | 키 분리, RT claim 추가, parseRefreshClaims |
| `config/JwtConfig.java` | accessSecretKey 빈 |
| `jwt/JwtTokenService.java` | Qualifier 지정 |
| `service/AuthService.java` | reissue 시그니처 변경, logout 추가 |
| `service/AuthServiceImpl.java` | rotation, revocation, reuse detection |
| `controller/AuthController.java` | logout/reissue 변경 |
| `controller/DevAuthController.java` | 새 RT 발급 방식 반영 |
| `jwt/JwtAuthenticationFilter.java` | type 이중 방어 |
| `error/ErrorCode.java` | SERVICE_UNAVAILABLE, REFRESH_TOKEN_REUSED |

## Test plan
- [ ] 로그인 → Redis에 `rt:jti:*` 키 생성 확인
- [ ] reissue → 새 쿠키 발급 + 옛 jti CONSUMED 상태 확인
- [ ] 옛 refresh token으로 재사용 시도 → 401 + family revoked 확인
- [ ] 로그아웃 → `rt:family:revoked:*` 키 생성 확인
- [ ] 로그아웃 후 reissue 시도 → 401 확인
- [ ] 레거시 토큰(jti/fid 없는) → 401 확인
- [ ] Refresh token을 Authorization 헤더에 넣기 → 거부 확인

## Note
`application.yml`은 Docker Secret으로 관리되어 git 미추적. 배포 시 `jwt.access-secret`, `jwt.refresh-secret`, `app.cookie.secure` 설정 추가 필요.